### PR TITLE
Updated if statement to be greater than or equal to number_sold 

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -268,7 +268,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Updated if condition on line 271 to "if product.number_sold >= int(number_sold)" from lesser than < to greater than >

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET http://localhost:8000/products?number_sold=2 


**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 50,
        "name": "Escalade EXT",
        "price": 926.92,
        "number_sold": 2,
        "description": "2008 Cadillac",
        "quantity": 2,
        "created_date": "2019-02-01",
        "location": "Lokavec",
        "image_path": null,
        "average_rating": 3.25
    }
]
```

## Testing

Description of how to test code...

- [ ] Test with GET http://localhost:8000/products?number_sold=2 or =1 in Postman
- [ ] Get product with that number


## Related Issues

- Fixes #21 