### PR TITLE
Added query params for location using __contains filter

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -250,6 +250,7 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
+        location= self.request.query_params.get('location', None)
 
         if order is not None:
             order_filter = order
@@ -273,6 +274,9 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+        
+        if location is not None:
+            products = products.filter(location__contains=location)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Added location query params in list function for /views/product.py (Line 253)
- if statement using __contains filtering to have location__contains = location to filter by location

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/products?location="Location here" gets all products with that location property (Ex: Cimara)

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 34,
        "name": "Chariot",
        "price": 1298.59,
        "number_sold": 0,
        "description": "1992 Mitsubishi",
        "quantity": 1,
        "created_date": "2019-04-27",
        "location": "Cimara",
        "image_path": null,
        "average_rating": null
    }
]
```

## Testing

Description of how to test code...

- [ ] Run server
- [ ] GET "http://localhost:8000/products?location=Cimara" gets all products with that location property

## Related Issues

- Fixes #14 